### PR TITLE
[fix] デフォルトのメールをgmailからyahooメールへ変更

### DIFF
--- a/src/config/const.php
+++ b/src/config/const.php
@@ -2,7 +2,7 @@
 
 return [
   'mail_connection' => [
-    'host'             => 'imap.gmail.com',
+    'host'             => 'imap.yahoo.co.jp',
     'port'             => 993,
     'subject'          => 'カード利用のお知らせ(本人ご利用分)',
     'encrypt_tyep'     => 'AES-128-CBC',


### PR DESCRIPTION
デフォルトのメールをgmailからyahooメールへ変更

https://github.com/matsukawakohei/account_book/issues/24