### PR TITLE
[fix] 明細の更新と削除にポリシーを追加

### DIFF
--- a/src/app/Http/Controllers/AccountController.php
+++ b/src/app/Http/Controllers/AccountController.php
@@ -64,7 +64,7 @@ class AccountController extends Controller
 
     public function edit(Account $account)
     {
-        if (is_null($account) || auth()->id() != $account->user_id) {
+        if (Auth::user()->cannot('update', $account)) {
             return redirect()->route('account.index')->with('warning_message', trans('account.invalid_account'));
         }
 
@@ -73,7 +73,7 @@ class AccountController extends Controller
 
     public function update(ManualAccountRequest $request, Account $account)
     {
-        if (is_null($account) || auth()->id() != $account->user_id) {
+        if (Auth::user()->cannot('update', $account)) {
             return redirect()->route('account.index')->with('warning_message', trans('account.invalid_account'));
         }
 
@@ -87,7 +87,7 @@ class AccountController extends Controller
 
     public function destory(Account $account)
     {
-        if (is_null($account) || auth()->id() != $account->user_id) {
+        if (Auth::user()->cannot('delete', $account)) {
             return redirect()->route('account.index')->with('warning_message', trans('account.invalid_account'));
         }
 

--- a/src/app/Policies/AccountPolicy.php
+++ b/src/app/Policies/AccountPolicy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class AccountPolicy
+{
+    /**
+     * Create a new policy instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/app/Policies/AccountPolicy.php
+++ b/src/app/Policies/AccountPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Models\Account;
 use App\Models\User;
 
 class AccountPolicy
@@ -12,5 +13,15 @@ class AccountPolicy
     public function __construct()
     {
         //
+    }
+
+    public function update(User $user, Account $account): bool
+    {
+        return $user->id === $account->user_id;
+    }
+
+    public function delete(User $user, Account $account): bool
+    {
+        return $user->id === $account->user_id;
     }
 }

--- a/src/tests/Feature/AccountTest.php
+++ b/src/tests/Feature/AccountTest.php
@@ -145,6 +145,24 @@ class AccountTest extends TestCase
     }
 
     /** @test */
+    public function 更新画面のテスト_更新対象が存在しない場合(): void
+    {
+        $user    = User::factory()->create();
+        $account = Account::create([
+            'user_id'    => $user->id,
+            'name'       => '明細5',
+            'amount'     => 5000,
+            'date'       => Carbon::now()->toDateString(),
+            'store_type' => StoreType::Manual,
+        ]);
+
+        $this->actingAs($user);
+        $url = route('account.edit', ['account' => 100]);
+        $this->get($url)
+            ->assertNotFound();
+    }
+
+    /** @test */
     public function 更新画面のテスト_明細のユーザーとログインユーザーが別の場合(): void
     {
         $user    = User::factory()->create();
@@ -219,6 +237,29 @@ class AccountTest extends TestCase
     }
 
     /** @test */
+    public function 更新のテスト_更新対象が存在しない場合(): void
+    {
+        $user    = User::factory()->create();
+        $account = Account::create([
+            'user_id'    => $user->id,
+            'name'       => '明細6',
+            'amount'     => 6000,
+            'date'       => Carbon::now()->toDateString(),
+            'store_type' => StoreType::Manual,
+        ]);
+        $param  = [
+            'name'         => '明細6_変更',
+            'amount'       => 6500,
+            'account_date' => Carbon::now()->toDateString(),
+        ];
+
+        $this->actingAs($user);
+        $url = route('account.update', ['account' => 101]);
+        $this->put($url, $param)
+            ->assertNotFound();
+    }
+
+    /** @test */
     public function 更新のテスト_明細のユーザーとログインユーザーが別の場合(): void
     {
         $user    = User::factory()->create();
@@ -283,6 +324,24 @@ class AccountTest extends TestCase
 
         $this->get(route('account.index'))
             ->assertSee('支出の削除が完了しました。');
+    }
+
+    /** @test */
+    public function 削除のテスト_削除対象が存在しない場合(): void
+    {
+        $user    = User::factory()->create();
+        $account = Account::create([
+            'user_id'    => $user->id,
+            'name'       => '明細7',
+            'amount'     => 7000,
+            'date'       => Carbon::now()->toDateString(),
+            'store_type' => StoreType::Manual,
+        ]);
+
+        $this->actingAs($user);
+        $url = route('account.delete', ['account' => 102]);
+        $this->delete($url)
+            ->assertNotFound();
     }
 
     /** @test */


### PR DESCRIPTION
明細の更新と削除にポリシーを追加し、明細の作成ユーザー以外からの更新・削除ができないように改修。

https://github.com/matsukawakohei/account_book/issues/65