### PR TITLE
[fix] 支出名のテキストフィールドのアイコンを変更

### DIFF
--- a/src/resources/views/account/create.blade.php
+++ b/src/resources/views/account/create.blade.php
@@ -29,7 +29,7 @@
 
                     <div class="input-group-append">
                         <div class="input-group-text">
-                            <span class="fas fa-user"></span>
+                            <span class="fas fa-wallet"></span>
                         </div>
                     </div>
 


### PR DESCRIPTION
支出名のテキストフィールドのアイコンを変更

https://github.com/matsukawakohei/account_book/issues/67